### PR TITLE
create pub when redisd restart

### DIFF
--- a/mk1.go
+++ b/mk1.go
@@ -249,6 +249,16 @@ func (mk1 *Mk1) Hset(args args.Hset, reply *reply.Hset) error {
 	return err
 }
 
+func (mk1 *Mk1) Createpub(args string, reply *struct{}) (err error) {
+	if mk1.pub != nil{
+		mk1.pub.Close()
+	}
+	if mk1.pub, err = publisher.New(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (mk1 *Mk1) init() {
 	const (
 		defaultPollInterval             = 5


### PR DESCRIPTION
This code is linked with start() in daemons.go where there is rpc call to the function here in mk1.go which will create new publisher for producing new data into redis.